### PR TITLE
Fix of some small interface bugs

### DIFF
--- a/addons/cognite/editor/scripts/itens/perception_context_item.gd
+++ b/addons/cognite/editor/scripts/itens/perception_context_item.gd
@@ -77,5 +77,5 @@ func _on_text_text_changed(new_text: String) -> void:
 	var word := Cognite.filter_string(new_text, "[a-zA-Z_]")
 	text.set_text(word)
 	text.caret_column = caret_position
-	perception_data.text = float(word)
+	perception_data.text = str(word)
 	assemble.atualize_context(context_id, context)

--- a/addons/cognite/node/assemble.gd
+++ b/addons/cognite/node/assemble.gd
@@ -100,6 +100,29 @@ func get_deed(id: int) -> Dictionary:
 	if deeds.has(id): return deeds[id]
 	return {}
 
+func clear_deeds() -> void:
+	var used: Dictionary = {}
+	var to_remove: Array = []
+	
+	for action in actions.values():
+		for deed_id in action.deed_list:
+			used[deed_id] = true
+	
+	for deed_id in deeds.keys():
+		if not used.has(deed_id):
+			to_remove.append(deed_id)
+	
+	for deed_id in to_remove:
+		deeds.erase(deed_id)
+	
+	for action in actions.values():
+		var valid_list: Array = []
+		
+		for deed_id in action.deed_list:
+			if deeds.has(deed_id):
+				valid_list.append(deed_id)
+		action.deed_list = valid_list
+
 
 func atualize_perception_runtime_value(perception_name: String, value):
 	perception_runtime_value[perception_name] = value

--- a/addons/cognite/node/cognite_node.gd
+++ b/addons/cognite/node/cognite_node.gd
@@ -26,6 +26,8 @@ func deed_action_finalized(deed_name: StringName):
 
 func _enter_tree() -> void:
 	if Engine.is_editor_hint(): return
+
+	cognite_assemble.clear_deeds()
 	
 	for context_id in cognite_assemble.contexts:
 		runtime_context[context_id] = CogniteRuntimeContext.new(cognite_assemble.contexts[context_id], cognite_assemble, self)

--- a/addons/cognite/runtime/cognite_runtime_action.gd
+++ b/addons/cognite/runtime/cognite_runtime_action.gd
@@ -84,7 +84,7 @@ func finish():
 	current_process = 0
 	
 	for deed in deeds:
-		deed = deed as CogniteRuntimeDeed
+		deed = deeds[deed] as CogniteRuntimeDeed
 		if deed.started.is_connected(cognite_node._on_deed_started):
 			deed.started.disconnect(cognite_node._on_deed_started)
 			


### PR DESCRIPTION
Fix in perception_context_item, where the text value was being converted to float instead of String. [Code](https://github.com/matheus-s-arruda/Cognite/commit/da3689bcd7a04931f8a5baafa2140ebce7ccb2e3)

Fix of a similar type conversion issue in cognite_runtime_action. [Code](https://github.com/matheus-s-arruda/Cognite/commit/91642d94d61d87e69d1a83f48f985a729547ea46)

Fix in cognite_runtime_action where the _init() function attempted to access a non-existent deed, this occurred due to the creation of “ghost actions” that remained in the actions list even after being removed through the interface. As a result, deed_list was not being properly updated as these ghost actions were generated.

A new clear_deeds function was added to Assembly to clean up remaining actions and update the deed_list. (Still unsure if the correct place to call this function is in CogniteNode _enter_tree().) [Code](https://github.com/matheus-s-arruda/Cognite/commit/c301ea358bbbd57e2bf98f456b965fc50722048b)
